### PR TITLE
Option to allow background streaming

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -168,7 +168,8 @@ class TVGuide(xbmcgui.WindowXML):
         if not self.isClosing:
             self.isClosing = True
             if self.player.isPlaying():
-                self.player.stop()
+                if ADDON.getSetting('background.stream') == 'false':
+                    self.player.stop()
             if self.database:
                 self.database.close(super(TVGuide, self).close)
             else:

--- a/resources/language/English (US)/strings.po
+++ b/resources/language/English (US)/strings.po
@@ -268,6 +268,12 @@ msgstr "24 hrs"
 
 #empty strings from id 30406 to 30499
 
+msgctxt "#30450"
+msgid "Allow streaming in background"
+msgstr "Allow streaming in background"
+
+#empty strings from id 30451 to 30499
+
 msgctxt "#30500"
 msgid "[B]Edit channel order and visibility[/B]"
 msgstr "[B]Edit channel order and visibility[/B]"

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -372,7 +372,13 @@ msgctxt "#30405"
 msgid "24 hrs"
 msgstr ""
 
-#empty strings from id 30406 to 30499
+#empty strings from id 30406 to 30449
+
+msgctxt "#30450"
+msgid "Allow streaming in background"
+msgstr ""
+
+#empty strings from id 30451 to 30499
 
 msgctxt "#30500"
 msgid "[B]Edit channel order and visibility[/B]"

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -27,6 +27,7 @@
 		<setting label="30121" type="lsep" />
         <setting id="background.service" label="30400" type="bool" default="false" />
         <setting id="service.interval" label="30401" type="enum" default="1" lvalues="30402|30403|30404|30405" visible="eq(-1,true)" />
+        <setting id="background.stream" label="30450" type="bool" default="false" />
 	</category>
 
 	<category label="30112">


### PR DESCRIPTION
Currently, it's not possible to stream the current channel in the background (when navigating out of the EPG guide).
It may just be me, but I like to be able to watch/listen to the stream whilst doing other things on Kodi, so I've added an option in (off by default) to allow the stream to continue playing when backing out of the guide.